### PR TITLE
Broken @RequestMapping annotation handling on class target

### DIFF
--- a/complete/src/main/java/hello/GreetingController.java
+++ b/complete/src/main/java/hello/GreetingController.java
@@ -1,14 +1,22 @@
 package hello;
 
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
 
 @Controller
+//@RequestMapping(value = {}, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+//@RequestMapping(path = {}, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+@RequestMapping(produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 public class GreetingController {
 
     @GetMapping("/greeting")
+    @ResponseBody
     public String greeting(@RequestParam(name="name", required=false, defaultValue="World") String name, Model model) {
         model.addAttribute("name", name);
         return "greeting";


### PR DESCRIPTION
The MVC tab in the Spring tool window fails to display the correct
handler mappings when there is a `@RequestMapping` annotation with the
default value of `{}` for its `path` or `value` elements.